### PR TITLE
Improve thread safety and ublk device lifecycle handling

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,6 +31,7 @@ func NewConfigManager(nisdConfigPath, volumeTrackingPath string) *ConfigManager 
 }
 
 func (cm *ConfigManager) LoadNisdConfig() error {
+
 	cm.Mutex.Lock()
 	defer cm.Mutex.Unlock()
 
@@ -96,8 +97,6 @@ func (cm *ConfigManager) UpdateNisdAvailableSize(nisdUUID string, sizeChange int
 }
 
 func (cm *ConfigManager) AddVolume(volume *types.Volume) error {
-	cm.Mutex.Lock()
-	defer cm.Mutex.Unlock()
 
 	nisd, exists := cm.controller.NisdMap[volume.NisdInfo.UUID.String()]
 	if !exists {
@@ -130,8 +129,6 @@ func (cm *ConfigManager) GetVolume(volumeID string) (*types.Volume, error) {
 }
 
 func (cm *ConfigManager) UpdateVolumeStatus(volumeID string, status types.VolumeStatus, nodeName string) error {
-	cm.Mutex.Lock()
-	defer cm.Mutex.Unlock()
 
 	for _, nisd := range cm.controller.NisdMap {
 		if vol, exists := nisd.VolMap[volumeID]; exists {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -123,7 +123,6 @@ func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 	}
 
 	volumeID := req.GetVolumeId()
-	cs.config.controller.cs.config.controller.NisdMap.VolMap.UblkPath
 
 	// Get volume info
 	volume, err := cs.config.GetVolume(volumeID)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -32,6 +32,7 @@ type Volume struct {
 	VolID      uuid.UUID    `yaml:"volumeID" json:"volumeID"`
 	NisdInfo   NisdInfo     `yaml:"nisdInfo" json:"nisdInfo"`
 	Size       int64        `yaml:"volumeSize" json:"volumeSize"`
+	Path       string       `yaml:"volumePath" json:"volumePath"`
 	NodeName   string       `yaml:"nodeName" json:"nodeName"`
 	Status     VolumeStatus `yaml:"status" json:"status"`
 	CreatedAt  time.Time    `yaml:"createdAt" json:"createdAt"`
@@ -47,6 +48,7 @@ type NodeVolume struct {
 	NisdInfo    NisdInfo     `yaml:"nisdInfo" json:"nisdInfo"`
 	NodeInfo    string       `yaml:"nodeInfo" json:"nodeInfo"`
 	UblkPath    string       `yaml:"ublkPath" json:"ublkPath"`
+	UblkPid     int          `yaml:"ublkPid" json:"ublkPid"`
 	Status      VolumeStatus `yaml:"status" json:"status"`
 	StagingPath string       `yaml:"stagingPath" json:"stagingPath"`
 	TargetPath  string       `yaml:"targetPath" json:"targetPath"`

--- a/test/test_client.go
+++ b/test/test_client.go
@@ -3,11 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
 	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"k8s.io/klog/v2"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 )
@@ -20,7 +20,7 @@ func main() {
 		grpc.WithTimeout(5*time.Second),
 	)
 	if err != nil {
-		log.Fatalf("Failed to connect to CSI driver: %v", err)
+		fmt.Errorf("Failed to connect to CSI driver: %v", err)
 	}
 	defer conn.Close()
 
@@ -31,10 +31,9 @@ func main() {
 
 	resp, err := client.GetPluginInfo(ctx, &csi.GetPluginInfoRequest{})
 	if err != nil {
-		log.Fatalf("GetPluginInfo failed: %v", err)
+		fmt.Errorf("GetPluginInfo failed: %v", err)
 	}
 
-	fmt.Printf("✅ Plugin Name: %s\n", resp.GetName())
-	fmt.Printf("✅ Plugin Version: %s\n", resp.GetVendorVersion())
+	klog.Infof("Plugin Name: %s", resp.GetName())
+	klog.Infof("Plugin Version: %s", resp.GetVendorVersion())
 }
-


### PR DESCRIPTION
- Exported ConfigManager.Mutex to allow external locking
- Added explicit locking in ControllerServer methods (CreateVolume, DeleteVolume, etc.)
- Modified ublkManager.CreateUblkDevice to return ublk process PID
- Updated DeleteUblkDevice to accept and use PID for proper cleanup
- Removed redundant internal locking in ConfigManager where caller now holds the lock
- Cleaned up logs and unnecessary lines in NodeServer