### PR TITLE
csi: add proper raw block volume support on node side

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -15,12 +15,12 @@ import (
 )
 
 var (
-	endpoint = flag.String("endpoint", "unix:///var/lib/kubelet/plugins/niova-block-csi/csi.sock", "CSI endpoint")
-	raftID   = flag.String("r", "", "pass the raft uuid")
-	nodeID   = flag.String("node-id", "", "Node ID")
-	ConfigPath         = flag.String("configpath", "./gossipNodes", "Path to gossip configuration file")
-	driverName         = flag.String("driver-name", "niova-block-csi", "Name of the CSI driver")
-	version            = flag.String("version", "v1.0.0", "Version of the CSI driver")
+	endpoint   = flag.String("endpoint", "unix:///var/lib/kubelet/plugins/niova-block-csi/csi.sock", "CSI endpoint")
+	raftID     = flag.String("r", "", "pass the raft uuid")
+	nodeID     = flag.String("node-id", "", "Node ID")
+	ConfigPath = flag.String("configpath", "./gossipNodes", "Path to gossip configuration file")
+	driverName = flag.String("driver-name", "niova-block-csi", "Name of the CSI driver")
+	version    = flag.String("version", "v1.0.0", "Version of the CSI driver")
 )
 
 func main() {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,4 +1,3 @@
-
 package config
 
 import (
@@ -13,14 +12,14 @@ import (
 )
 
 type ConfigManager struct {
-	CpConfigPath     string
-	Controller         *types.Controller
-	Mutex              sync.RWMutex
+	CpConfigPath string
+	Controller   *types.Controller
+	Mutex        sync.RWMutex
 }
 
 func NewConfigManager(cpConfigPath string) *ConfigManager {
 	return &ConfigManager{
-		CpConfigPath:     cpConfigPath,
+		CpConfigPath: cpConfigPath,
 		Controller: &types.Controller{
 			VdevMap: make(map[string]*types.Vdev),
 		},
@@ -33,7 +32,6 @@ func (cm *ConfigManager) LoadCpClient(c *cpClient.CliCFuncs) error {
 	return nil
 }
 
-
 func (cm *ConfigManager) GetController() *types.Controller {
 	cm.Mutex.Lock()
 	defer cm.Mutex.Unlock()
@@ -45,8 +43,8 @@ func (cm *ConfigManager) AllocVdev(requiredSize int64) (string, error) {
 	defer cm.Mutex.RUnlock()
 	// TODO: NumReplica should be passed from PVC file.
 	Vdev := &ctlplfl.VdevReq{
-		Vdev: &ctlplfl.VdevCfg {
-			Size: requiredSize,
+		Vdev: &ctlplfl.VdevCfg{
+			Size:       requiredSize,
 			NumReplica: 1,
 		},
 	}
@@ -61,7 +59,6 @@ func (cm *ConfigManager) AllocVdev(requiredSize int64) (string, error) {
 	return resp.ID, nil
 }
 
-
 func (cm *ConfigManager) AddVolumeLocked(volume *types.Volume) error {
 	vdev, exists := cm.Controller.VdevMap[volume.VolID]
 	if !exists {
@@ -70,7 +67,6 @@ func (cm *ConfigManager) AddVolumeLocked(volume *types.Volume) error {
 	vdev.VolMap[volume.VolID] = volume
 	return nil
 }
-
 
 func (cm *ConfigManager) RemoveVolume(volumeID string) error {
 
@@ -114,4 +110,3 @@ func (cm *ConfigManager) UpdateVolumeStatus(volumeID string, status types.Volume
 	}
 	return fmt.Errorf("volume %s not found", volumeID)
 }
-

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -44,14 +44,14 @@ func (cm *ConfigManager) AllocVdev(requiredSize int64) (string, error) {
 	cm.Mutex.RLock()
 	defer cm.Mutex.RUnlock()
 	// TODO: NumReplica should be passed from PVC file.
-	Vdev := ctlplfl.Vdev{
-		Cfg: ctlplfl.VdevCfg {
+	Vdev := &ctlplfl.VdevReq{
+		Vdev: &ctlplfl.VdevCfg {
 			Size: requiredSize,
 			NumReplica: 1,
 		},
 	}
-	klog.Infof("Create vdev of size", Vdev.Cfg.Size)
-	resp, err := cm.Controller.Cpclient.CreateVdev(&Vdev)
+	klog.Infof("Create vdev of size", Vdev.Vdev.Size)
+	resp, err := cm.Controller.Cpclient.CreateVdev(Vdev)
 	if err != nil {
 		klog.Infof("nisd is not allocated", err)
 		return "", fmt.Errorf("failed to get nisd %w", err)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,6 +27,9 @@ func NewConfigManager(cpConfigPath string) *ConfigManager {
 }
 
 func (cm *ConfigManager) LoadCpClient(c *cpClient.CliCFuncs) error {
+	if c == nil {
+		return fmt.Errorf("CP client Cannot be Nil")
+	}
 	cm.Controller.VdevMap = make(map[string]*types.Vdev)
 	cm.Controller.Cpclient = c
 	return nil

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -233,10 +233,10 @@ func (cs *ControllerServer) ValidateVolumeCapabilities(ctx context.Context, req 
 	}
 	cs.config.Mutex.Unlock()
 	for _, cap := range req.GetVolumeCapabilities() {
-		if cap.GetBlock() != nil && vol.VolumeMode != types.BLOCK_MODE {
+		if cap.GetBlock() != nil && vol.VolumeMode == types.BLOCK_MODE {
 			return &csi.ValidateVolumeCapabilitiesResponse{}, nil
 		}
-		if cap.GetMount() != nil && vol.VolumeMode != types.MOUNT_MODE {
+		if cap.GetMount() != nil && vol.VolumeMode == types.MOUNT_MODE {
 			return &csi.ValidateVolumeCapabilitiesResponse{}, nil
 		}
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -70,9 +70,9 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	if cap.GetMount() == nil && cap.GetBlock() == nil {
 		return nil, status.Error(codes.InvalidArgument, "Unsupported volume capability")
 	}
-	volumeMode := "mount"
+	volumeMode := types.MOUNT_MODE
 	if cap.GetBlock() != nil {
-		volumeMode = "block"
+		volumeMode = types.BLOCK_MODE
 	}
 	// Allocate Vdev of required size
 	volumeID, err := cs.config.AllocVdev(volumeSize)
@@ -233,10 +233,10 @@ func (cs *ControllerServer) ValidateVolumeCapabilities(ctx context.Context, req 
 	}
 	cs.config.Mutex.Unlock()
 	for _, cap := range req.GetVolumeCapabilities() {
-		if cap.GetBlock() != nil && vol.VolumeMode != "block" {
+		if cap.GetBlock() != nil && vol.VolumeMode != types.BLOCK_MODE {
 			return &csi.ValidateVolumeCapabilitiesResponse{}, nil
 		}
-		if cap.GetMount() != nil && vol.VolumeMode != "mount" {
+		if cap.GetMount() != nil && vol.VolumeMode != types.MOUNT_MODE {
 			return &csi.ValidateVolumeCapabilitiesResponse{}, nil
 		}
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -62,7 +62,18 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	if volumeSize == 0 {
 		volumeSize = 1024 * 1024 * 1024 // 1GB default
 	}
-
+	caps := req.GetVolumeCapabilities()
+	if len(caps) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "VolumeCapabilities missing")
+	}
+	cap := caps[0]
+	if cap.GetMount() == nil && cap.GetBlock() == nil {
+		return nil, status.Error(codes.InvalidArgument, "Unsupported volume capability")
+	}
+	volumeMode := "mount"
+	if cap.GetBlock() != nil {
+		volumeMode = "block"
+	}
 	// Allocate Vdev of required size
 	volumeID, err := cs.config.AllocVdev(volumeSize)
 	if err != nil {
@@ -72,16 +83,17 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	klog.Infof("Allocated vdevid is : %s", volumeID)
 	// Create volume structure
 	volume := &types.Volume{
-		VolID:     volumeID,
-		Size:      volumeSize,
-		Status:    types.VolumeStatusCreated,
-		CreatedAt: time.Now(),
+		VolID:      volumeID,
+		Size:       volumeSize,
+		Status:     types.VolumeStatusCreated,
+		VolumeMode: volumeMode,
+		CreatedAt:  time.Now(),
 	}
 	cs.config.Mutex.Lock()
 	if _, exists := cs.config.Controller.VdevMap[volumeID]; !exists {
 		cs.config.Controller.VdevMap[volumeID] = &types.Vdev{
 			VolMap: make(map[string]*types.Volume),
-    		}
+		}
 	}
 	// Add volume to config manager
 	if err := cs.config.AddVolumeLocked(volume); err != nil {
@@ -165,7 +177,7 @@ func (cs *ControllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 
 	return &csi.ControllerPublishVolumeResponse{
 		PublishContext: map[string]string{
-			"volumeID": volume.VolID,
+			"volumeID":   volume.VolID,
 			"volumeSize": fmt.Sprintf("%d", volume.Size),
 		},
 	}, nil
@@ -214,13 +226,20 @@ func (cs *ControllerServer) ValidateVolumeCapabilities(ctx context.Context, req 
 
 	// Check if volume exists
 	cs.config.Mutex.Lock()
-	_, err := cs.config.GetVolume(req.GetVolumeId())
+	vol, err := cs.config.GetVolume(req.GetVolumeId())
 	if err != nil {
 		cs.config.Mutex.Unlock()
 		return nil, status.Error(codes.NotFound, fmt.Sprintf("Volume %s not found", req.GetVolumeId()))
 	}
 	cs.config.Mutex.Unlock()
-
+	for _, cap := range req.GetVolumeCapabilities() {
+		if cap.GetBlock() != nil && vol.VolumeMode != "block" {
+			return &csi.ValidateVolumeCapabilitiesResponse{}, nil
+		}
+		if cap.GetMount() != nil && vol.VolumeMode != "mount" {
+			return &csi.ValidateVolumeCapabilitiesResponse{}, nil
+		}
+	}
 	// For now, we support all requested capabilities
 	return &csi.ValidateVolumeCapabilitiesResponse{
 		Confirmed: &csi.ValidateVolumeCapabilitiesResponse_Confirmed{
@@ -242,8 +261,8 @@ func (cs *ControllerServer) ListVolumes(ctx context.Context, req *csi.ListVolume
 					VolumeId:      volume.VolID,
 					CapacityBytes: volume.Size,
 					VolumeContext: map[string]string{
-						"status":     string(volume.Status),
-						"nodeName":   volume.NodeName,
+						"status":   string(volume.Status),
+						"nodeName": volume.NodeName,
 					},
 				},
 			})

--- a/pkg/node/mount.go
+++ b/pkg/node/mount.go
@@ -109,7 +109,7 @@ func (mm *MountManager) BindRawBlock(sourcePath, targetPath string) error {
 	// Check if already mounted
 	mounted, err := mm.mounter.IsMountPoint(targetPath)
 	if err != nil {
-		 return fmt.Errorf("failed to check if target is mounted: %v", err)
+		return fmt.Errorf("failed to check if target is mounted: %v", err)
 	}
 	if mounted {
 		klog.Infof("Path %s is already mounted at %s", sourcePath, targetPath)
@@ -119,7 +119,7 @@ func (mm *MountManager) BindRawBlock(sourcePath, targetPath string) error {
 	if err = mm.mounter.Mount(sourcePath, targetPath, "", []string{"bind"}); err != nil {
 		return fmt.Errorf("failed to bind mount %s to %s: %v", sourcePath, targetPath, err)
 	}
-	return nil 
+	return nil
 }
 
 func (mm *MountManager) BindMount(sourcePath, targetPath string) error {

--- a/pkg/node/mount.go
+++ b/pkg/node/mount.go
@@ -180,8 +180,9 @@ func (mm *MountManager) CleanupMountPoint(targetPath string) error {
 	}
 
 	// Remove directory if empty
-	if err := os.Remove(targetPath); err != nil && !os.IsNotExist(err) {
+	if err := os.Remove(targetPath); err != nil || !os.IsNotExist(err) {
 		klog.Warningf("Failed to remove directory %s: %v", targetPath, err)
+		return fmt.Errorf("Failed to remove the path %s with err %v", targetPath, err)
 	}
 
 	return nil

--- a/pkg/node/mount.go
+++ b/pkg/node/mount.go
@@ -100,14 +100,22 @@ func (mm *MountManager) FormatAndMountDevice(devicePath, targetPath, requestedFs
 	return nil
 }
 
+func (mm *MountManager) BindRawBlock(sourcePath, targetPath string) error {
+	info, _ := os.Stat(targetPath)
+	klog.Infof("targetPath isDir=%v mode=%v", info.IsDir(), info.Mode())
+	// Perform bind mount
+	if err := mm.mounter.Mount(sourcePath, targetPath, "", []string{"bind"}); err != nil {
+		return fmt.Errorf("failed to bind mount %s to %s: %v", sourcePath, targetPath, err)
+	}
+	return nil 
+}
+
 func (mm *MountManager) BindMount(sourcePath, targetPath string) error {
 	klog.Infof("Bind mounting %s to %s", sourcePath, targetPath)
-
 	// Create target directory if it doesn't exist
 	if err := os.MkdirAll(targetPath, 0755); err != nil {
 		return fmt.Errorf("failed to create target directory %s: %v", targetPath, err)
 	}
-
 	// Check if already mounted
 	mounted, err := mm.mounter.IsMountPoint(targetPath)
 	if err != nil {

--- a/pkg/node/mount.go
+++ b/pkg/node/mount.go
@@ -101,10 +101,22 @@ func (mm *MountManager) FormatAndMountDevice(devicePath, targetPath, requestedFs
 }
 
 func (mm *MountManager) BindRawBlock(sourcePath, targetPath string) error {
-	info, _ := os.Stat(targetPath)
+	info, err := os.Stat(targetPath)
+	if err != nil {
+		return fmt.Errorf("failed to find target path %s: %v", targetPath, err)
+	}
 	klog.Infof("targetPath isDir=%v mode=%v", info.IsDir(), info.Mode())
+	// Check if already mounted
+	mounted, err := mm.mounter.IsMountPoint(targetPath)
+	if err != nil {
+		 return fmt.Errorf("failed to check if target is mounted: %v", err)
+	}
+	if mounted {
+		klog.Infof("Path %s is already mounted at %s", sourcePath, targetPath)
+		return nil
+	}
 	// Perform bind mount
-	if err := mm.mounter.Mount(sourcePath, targetPath, "", []string{"bind"}); err != nil {
+	if err = mm.mounter.Mount(sourcePath, targetPath, "", []string{"bind"}); err != nil {
 		return fmt.Errorf("failed to bind mount %s to %s: %v", sourcePath, targetPath, err)
 	}
 	return nil 

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -83,7 +83,7 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 
 	ns.mutex.Lock()
 	defer ns.mutex.Unlock()
-	var volUUID uuid.UUID 
+	var volUUID uuid.UUID
 	// Create ublk device
 	ublkDevicePath, ublkpid, err := ns.ublkManager.CreateUblkDevice(volumeID, volumeSizeStr)
 	if err != nil {

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"sync"
 
@@ -61,9 +62,15 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	if req.GetStagingTargetPath() == "" {
 		return nil, status.Error(codes.InvalidArgument, "Staging target path cannot be empty")
 	}
-
 	if req.GetVolumeCapability() == nil {
-		return nil, status.Error(codes.InvalidArgument, "Volume capability cannot be empty")
+		return nil, status.Error(codes.InvalidArgument, "Volume capabilities cannot be empty")
+	}
+	cap := req.GetVolumeCapability()
+	isBlock := cap.GetBlock() != nil
+	isMount := cap.GetMount() != nil
+	mode := "mount"
+	if isBlock {
+		mode = "block"
 	}
 
 	volumeID := req.GetVolumeId()
@@ -77,43 +84,45 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 
 	ns.mutex.Lock()
 	defer ns.mutex.Unlock()
-
+	var volUUID uuid.UUID 
 	// Create ublk device
 	ublkDevicePath, ublkpid, err := ns.ublkManager.CreateUblkDevice(volumeID, volumeSizeStr)
 	if err != nil {
 		return nil, status.Error(codes.Internal, fmt.Sprintf("Failed to create ublk device: %v", err))
 	}
-
-	// Determine filesystem type from volume capability
-	fsType := "ext4" // default
-	if req.GetVolumeCapability().GetMount() != nil {
-		if req.GetVolumeCapability().GetMount().GetFsType() != "" {
-			fsType = req.GetVolumeCapability().GetMount().GetFsType()
+	if isMount {
+		// Determine filesystem type from volume capability
+		fsType := "ext4" // default
+		if req.GetVolumeCapability().GetMount() != nil {
+			if req.GetVolumeCapability().GetMount().GetFsType() != "" {
+				fsType = req.GetVolumeCapability().GetMount().GetFsType()
+			}
 		}
-	}
 
-	// Format and mount the ublk device to staging path
-	if err := ns.mountManager.FormatAndMountDevice(ublkDevicePath, stagingPath, fsType); err != nil {
-		// Cleanup ublk device on failure
-		ns.ublkManager.DeleteUblkDevice(volumeID, ublkDevicePath, ublkpid)
-		return nil, status.Error(codes.Internal, fmt.Sprintf("Failed to mount device: %v", err))
-	}
+		// Format and mount the ublk device to staging path
+		if err := ns.mountManager.FormatAndMountDevice(ublkDevicePath, stagingPath, fsType); err != nil {
+			// Cleanup ublk device on failure
+			ns.ublkManager.DeleteUblkDevice(volumeID, ublkDevicePath, ublkpid)
+			return nil, status.Error(codes.Internal, fmt.Sprintf("Failed to mount device: %v", err))
+		}
 
-	// Parse volume ID to UUID
-	volUUID, err := uuid.Parse(volumeID)
-	if err != nil {
-		klog.Errorf("Failed to parse volume ID %s: %v", volumeID, err)
-		ns.ublkManager.DeleteUblkDevice(volumeID, ublkDevicePath, ublkpid)
-		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("Invalid volume ID format: %v", err))
+		// Parse volume ID to UUID
+		volUUID, err = uuid.Parse(volumeID)
+		if err != nil {
+			klog.Errorf("Failed to parse volume ID %s: %v", volumeID, err)
+			ns.ublkManager.DeleteUblkDevice(volumeID, ublkDevicePath, ublkpid)
+			return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("Invalid volume ID format: %v", err))
+		}
 	}
 
 	// Create or update node volume entry
 	nodeVolume := &types.NodeVolume{
-		VolID: volUUID,
+		VolID:       volUUID,
 		NodeInfo:    ns.nodeID,
 		UblkPath:    ublkDevicePath,
 		UblkPid:     ublkpid,
 		Status:      types.VolumeStatusAttached,
+		VolumeMode:  mode,
 		StagingPath: stagingPath,
 	}
 
@@ -147,8 +156,10 @@ func (ns *NodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 	}
 
 	// Unmount from staging path
-	if err := ns.mountManager.Unmount(stagingPath); err != nil {
-		return nil, status.Error(codes.Internal, fmt.Sprintf("Failed to unmount staging path: %v", err))
+	if nodeVol.VolumeMode == "mount" {
+		if err := ns.mountManager.Unmount(stagingPath); err != nil {
+			return nil, status.Error(codes.Internal, fmt.Sprintf("Failed to unmount staging path: %v", err))
+		}
 	}
 
 	// Delete ublk device if it exists
@@ -199,8 +210,19 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 
 	// Check if volume capability is block or filesystem
 	if req.GetVolumeCapability().GetBlock() != nil {
+		// Ensure parent dir exists
+		if err := os.MkdirAll(filepath.Dir(targetPath), 0750); err != nil {
+			return nil, status.Error(codes.Internal, err.Error())
+		}
+
+		// Create target file
+		f, err := os.OpenFile(targetPath, os.O_CREATE, 0600)
+		if err != nil {
+			return nil, status.Error(codes.Internal, err.Error())
+		}
+		f.Close()
 		// Block volume - bind mount the ublk device directly
-		if err := ns.mountManager.BindMount(nodeVol.UblkPath, targetPath); err != nil {
+		if err := ns.mountManager.BindRawBlock(nodeVol.UblkPath, targetPath); err != nil {
 			return nil, status.Error(codes.Internal, fmt.Sprintf("Failed to bind mount block device: %v", err))
 		}
 	} else {
@@ -246,8 +268,12 @@ func (ns *NodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 	}
 
 	// Clean up target path
-	if err := ns.mountManager.CleanupMountPoint(targetPath); err != nil {
-		klog.Warningf("Failed to cleanup target path %s: %v", targetPath, err)
+	if nodeVol.VolumeMode == "block" {
+		_ = os.Remove(targetPath)
+	} else {
+		if err := ns.mountManager.CleanupMountPoint(targetPath); err != nil {
+			klog.Warningf("Failed to cleanup target path %s: %v", targetPath, err)
+		}
 	}
 
 	// Clear target path from node volume
@@ -267,7 +293,11 @@ func (ns *NodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVo
 	if req.GetVolumePath() == "" {
 		return nil, status.Error(codes.InvalidArgument, "Volume path cannot be empty")
 	}
-
+	if nodeVol, ok := ns.node.VolMap[req.GetVolumeId()]; ok {
+		if nodeVol.VolumeMode == "block" {
+			return nil, status.Error(codes.Unimplemented, "Block volume stats not supported")
+		}
+	}
 	volumePath := req.GetVolumePath()
 
 	// Check if path exists

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -68,9 +68,9 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	cap := req.GetVolumeCapability()
 	isBlock := cap.GetBlock() != nil
 	isMount := cap.GetMount() != nil
-	mode := "mount"
+	mode := types.MOUNT_MODE
 	if isBlock {
-		mode = "block"
+		mode = types.BLOCK_MODE
 	}
 
 	volumeID := req.GetVolumeId()
@@ -92,13 +92,13 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	}
 	if isMount {
 		// Determine filesystem type from volume capability
+		// TODO: Get File system type from yml
 		fsType := "ext4" // default
 		if req.GetVolumeCapability().GetMount() != nil {
 			if req.GetVolumeCapability().GetMount().GetFsType() != "" {
 				fsType = req.GetVolumeCapability().GetMount().GetFsType()
 			}
 		}
-
 		// Format and mount the ublk device to staging path
 		if err := ns.mountManager.FormatAndMountDevice(ublkDevicePath, stagingPath, fsType); err != nil {
 			// Cleanup ublk device on failure
@@ -156,7 +156,7 @@ func (ns *NodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 	}
 
 	// Unmount from staging path
-	if nodeVol.VolumeMode == "mount" {
+	if nodeVol.VolumeMode == types.MOUNT_MODE {
 		if err := ns.mountManager.Unmount(stagingPath); err != nil {
 			return nil, status.Error(codes.Internal, fmt.Sprintf("Failed to unmount staging path: %v", err))
 		}
@@ -268,7 +268,7 @@ func (ns *NodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 	}
 
 	// Clean up target path
-	if nodeVol.VolumeMode == "block" {
+	if nodeVol.VolumeMode == types.BLOCK_MODE {
 		_ = os.Remove(targetPath)
 	} else {
 		if err := ns.mountManager.CleanupMountPoint(targetPath); err != nil {
@@ -294,7 +294,7 @@ func (ns *NodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVo
 		return nil, status.Error(codes.InvalidArgument, "Volume path cannot be empty")
 	}
 	if nodeVol, ok := ns.node.VolMap[req.GetVolumeId()]; ok {
-		if nodeVol.VolumeMode == "block" {
+		if nodeVol.VolumeMode == types.BLOCK_MODE {
 			return nil, status.Error(codes.Unimplemented, "Block volume stats not supported")
 		}
 	}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -67,7 +67,6 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	}
 	cap := req.GetVolumeCapability()
 	isBlock := cap.GetBlock() != nil
-	isMount := cap.GetMount() != nil
 	mode := types.MOUNT_MODE
 	if isBlock {
 		mode = types.BLOCK_MODE
@@ -90,7 +89,7 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	if err != nil {
 		return nil, status.Error(codes.Internal, fmt.Sprintf("Failed to create ublk device: %v", err))
 	}
-	if isMount {
+	if mode == types.MOUNT_MODE {
 		// Determine filesystem type from volume capability
 		// TODO: Get File system type from yml
 		fsType := "ext4" // default
@@ -105,16 +104,15 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 			ns.ublkManager.DeleteUblkDevice(volumeID, ublkDevicePath, ublkpid)
 			return nil, status.Error(codes.Internal, fmt.Sprintf("Failed to mount device: %v", err))
 		}
-
-		// Parse volume ID to UUID
-		volUUID, err = uuid.Parse(volumeID)
-		if err != nil {
-			klog.Errorf("Failed to parse volume ID %s: %v", volumeID, err)
-			ns.ublkManager.DeleteUblkDevice(volumeID, ublkDevicePath, ublkpid)
-			return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("Invalid volume ID format: %v", err))
-		}
 	}
 
+	// Parse volume ID to UUID
+	volUUID, err = uuid.Parse(volumeID)
+	if err != nil {
+		klog.Errorf("Failed to parse volume ID %s: %v", volumeID, err)
+		ns.ublkManager.DeleteUblkDevice(volumeID, ublkDevicePath, ublkpid)
+		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("Invalid volume ID format: %v", err))
+	}
 	// Create or update node volume entry
 	nodeVolume := &types.NodeVolume{
 		VolID:       volUUID,

--- a/pkg/node/ublk.go
+++ b/pkg/node/ublk.go
@@ -95,22 +95,6 @@ func prepareTargetPath(nisdUUID, nisdIPAddr string, nisdPort int) string {
 	return tPath
 }
 
-func (um *UblkManager) IsUblkDeviceActive(ublkDevicePath string) bool {
-	if _, err := os.Stat(ublkDevicePath); err != nil {
-		return false
-	}
-	return true
-}
-
-func (um *UblkManager) generateUblkID(volumeID string) string {
-	// Generate a shorter ID from volume UUID for ublk device
-	// Take first 8 characters of volume ID
-	if len(volumeID) >= 8 {
-		return volumeID[:8]
-	}
-	return volumeID
-}
-
 func (um *UblkManager) extractUblkID(ublkDevicePath string) string {
 	// Extract ublk ID from device path like /dev/ublk123 -> 123
 	base := filepath.Base(ublkDevicePath)

--- a/pkg/node/ublk.go
+++ b/pkg/node/ublk.go
@@ -33,7 +33,7 @@ func NewUblkManager() *UblkManager {
 }
 
 func (um *UblkManager) CreateUblkDevice(volumeID, volumesize string) (string, int, error) {
-	klog.Infof("Creating ublk device for volume %s",volumeID)
+	klog.Infof("Creating ublk device for volume %s", volumeID)
 
 	beforeublkDevices, err := lsblkDevices()
 	if err != nil {
@@ -52,14 +52,14 @@ func (um *UblkManager) CreateUblkDevice(volumeID, volumesize string) (string, in
 	)
 	cmd.Env = append(cmd.Env,
 		fmt.Sprintf("LD_LIBRARY_PATH=%s", ldLibraryPath),
-		fmt.Sprintf("NIOVA_GOSSIP_PATH=%s",os.Getenv("NIOVA_GOSSIP_PATH")),
-		fmt.Sprintf("NIOVA_GOSSIP_KEY=%s",os.Getenv("NIOVA_GOSSIP_KEY")),
+		fmt.Sprintf("NIOVA_GOSSIP_PATH=%s", os.Getenv("NIOVA_GOSSIP_PATH")),
+		fmt.Sprintf("NIOVA_GOSSIP_KEY=%s", os.Getenv("NIOVA_GOSSIP_KEY")),
 	)
 	cmd.Dir = workingDir
 	if err := cmd.Start(); err != nil {
 		return "", -1, status.Errorf(codes.Internal, "failed to start ublk: %v", err)
 	}
-	
+
 	klog.Infof("ENV variables gossipPath: %s and raftuuid: %s ", os.Getenv("NIOVA_GOSSIP_PATH"), os.Getenv("NIOVA_GOSSIP_KEY"))
 	klog.Infof("Executing command: %s", cmd.String())
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,9 +1,10 @@
 package types
 
 import (
+	"time"
+
 	cpClient "github.com/00pauln00/niova-mdsvc/controlplane/ctlplanefuncs/client"
 	"github.com/google/uuid"
-	"time"
 )
 
 type VolumeStatus string
@@ -26,6 +27,7 @@ type Volume struct {
 	Path       string       `yaml:"volumePath" json:"volumePath"`
 	NodeName   string       `yaml:"nodeName" json:"nodeName"`
 	Status     VolumeStatus `yaml:"status" json:"status"`
+	VolumeMode string       `yaml:"volumeMode" json:"volumeMode"`
 	CreatedAt  time.Time    `yaml:"createdAt" json:"createdAt"`
 	AttachedAt *time.Time   `yaml:"attachedAt,omitempty" json:"attachedAt,omitempty"`
 }
@@ -41,6 +43,7 @@ type NodeVolume struct {
 	UblkPath    string       `yaml:"ublkPath" json:"ublkPath"`
 	UblkPid     int          `yaml:"ublkPid" json:"ublkPid"`
 	Status      VolumeStatus `yaml:"status" json:"status"`
+	VolumeMode  string       `yaml:"volumeMode" json:"volumeMode"`
 	StagingPath string       `yaml:"stagingPath" json:"stagingPath"`
 	TargetPath  string       `yaml:"targetPath" json:"targetPath"`
 }
@@ -52,4 +55,3 @@ type Node struct {
 type VolumeTrackingFile struct {
 	Volumes []*Volume `yaml:"volumes" json:"volumes"`
 }
-

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -11,6 +11,8 @@ type VolumeStatus string
 
 const (
 	SrcCP                             = "control-plane"
+	BLOCK_MODE			  = "block"
+	MOUNT_MODE			  = "mount"
 	VolumeStatusCreated  VolumeStatus = "created"
 	VolumeStatusAttached VolumeStatus = "attached"
 	VolumeStatusDetached VolumeStatus = "detached"

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -11,8 +11,8 @@ type VolumeStatus string
 
 const (
 	SrcCP                             = "control-plane"
-	BLOCK_MODE			  = "block"
-	MOUNT_MODE			  = "mount"
+	BLOCK_MODE                        = "block"
+	MOUNT_MODE                        = "mount"
 	VolumeStatusCreated  VolumeStatus = "created"
 	VolumeStatusAttached VolumeStatus = "attached"
 	VolumeStatusDetached VolumeStatus = "detached"


### PR DESCRIPTION
	- Distinguish block vs filesystem volumes using VolumeCapability
	- Skip formatting and staging mounts for block volumes
	- Use direct syscall.Mount for raw block device publish
	- Avoid mount-utils helpers (IsMountPoint / BindMount) for block targets
	- Create file-based target paths for block volumes
	- Track volumeMode in controller and node state