### PR TITLE
Update deployment manifests to use Quay.io images

### DIFF
--- a/deploy/niova-csi-con.yml
+++ b/deploy/niova-csi-con.yml
@@ -19,7 +19,7 @@ spec:
       hostPID: true
       containers:
         - name: niova-csi
-          image: paro1618/niova-csi:controller-v4
+          image: quay.io/niova/csi-controller:latest
           securityContext:
             privileged: true
             capabilities:

--- a/deploy/niova-csi-nod.yml
+++ b/deploy/niova-csi-nod.yml
@@ -16,7 +16,7 @@ spec:
       hostPID: true
       containers:
         - name: niova-csi
-          image: paro1618/niova-csi:node-v4
+          image: quay.io/niova/csi-node:latest
           securityContext:
             privileged: true
             capabilities:


### PR DESCRIPTION
Replace old Docker Hub images (paro1618/niova-csi) with new Quay.io images.

Changes:
- Controller: quay.io/niova/niova-block-csi:controller-latest
- Node: quay.io/niova/niova-block-csi:node-latest

These images are built and published via GitHub Actions workflow in the niova-block repository.