### PR TITLE
Update deployment manifests to use correct Quay.io image names

### DIFF
--- a/deploy/niova-csi-con.yml
+++ b/deploy/niova-csi-con.yml
@@ -19,7 +19,7 @@ spec:
       hostPID: true
       containers:
         - name: niova-csi
-          image: paro1618/niova-csi:controller-v4
+          image: quay.io/niova/csi-controller:latest
           securityContext:
             privileged: true
             capabilities:

--- a/deploy/niova-csi-nod.yml
+++ b/deploy/niova-csi-nod.yml
@@ -16,7 +16,7 @@ spec:
       hostPID: true
       containers:
         - name: niova-csi
-          image: paro1618/niova-csi:node-v4
+          image: quay.io/niova/csi-node:latest
           securityContext:
             privileged: true
             capabilities:


### PR DESCRIPTION
Replace old Docker Hub images with the correct Quay.io repository names:
- Controller: quay.io/niova/csi-controller:latest
- Node: quay.io/niova/csi-node:latest

These match the actual Quay.io repository structure where controller and node images are in separate repositories.